### PR TITLE
Fix HTTPS verification using certifi

### DIFF
--- a/igp/login.py
+++ b/igp/login.py
@@ -2,6 +2,7 @@
 
 from typing import Dict
 import requests
+import certifi
 
 from .config import base_url, headers
 
@@ -38,6 +39,12 @@ def login(username: str, password: str, remember: bool = False) -> Dict:
         'ajax': 1,
     }
 
-    response = requests.post(base_url, headers=headers, params=params, data=payload)
+    response = requests.post(
+        base_url,
+        headers=headers,
+        params=params,
+        data=payload,
+        verify=certifi.where(),
+    )
     response.raise_for_status()
     return response.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+certifi


### PR DESCRIPTION
## Summary
- verify HTTPS requests to IGP Manager using certifi
- document certifi dependency

## Testing
- `python3 -m py_compile main.py igp/*.py`
- `pip install requests certifi` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68507aeeb2b48325a3710e2a41a5c90d